### PR TITLE
build: add agent version to image and build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,4 +52,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: AGENT_VERSION=${{ steps.release.outputs.version }}
           tags: public.ecr.aws/odigos/agents/nodejs-community:${{ steps.release.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM node:22 AS nodejs-community-build
+ARG AGENT_VERSION
 WORKDIR /opentelemetry-node
 COPY package.json yarn.lock .
 RUN yarn install --frozen-lockfile
 COPY . .
+RUN echo "export const VERSION = \"$AGENT_VERSION\";" > ./src/version.ts
 RUN yarn compile
 
 # this build step is only for the production node_modules.


### PR DESCRIPTION
fixes: CORE-200

Adding the version of the agent into the source code during build time to show it correctly in detected resources