### PR TITLE
build: include v in the version and image tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,5 +58,5 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          build-args: AGENT_VERSION=${{ steps.release.outputs.version }}
-          tags: public.ecr.aws/odigos/agents/nodejs-community:${{ steps.release.outputs.version }}
+          build-args: AGENT_VERSION=${{ steps.release.outputs.tag_name }}
+          tags: public.ecr.aws/odigos/agents/nodejs-community:${{ steps.release.outputs.tag_name }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
+    "include-v-in-tag": true,
     "packages": {
         ".": {
             "release-type": "node"


### PR DESCRIPTION
fixes: CORE-200

publish the images like `v0.0.3` instead of `0.0.3`