### PR TITLE
build: add bootstrap sha for first release in new format

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,3 +67,12 @@ jobs:
           push: true
           build-args: AGENT_VERSION=${{ needs.release-pr.outputs.tag_name }}
           tags: ${{ env.ECR_REPO }}:${{ needs.release-pr.outputs.tag_name }},${{ env.ECR_REPO }}:latest
+
+      - name: Notify Slack
+        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
+        with: 
+          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
+          success-description: "Published a new release of OpenTelemetry Node.js Community Agent"
+          failure-description: "ERROR: Failed to publish a new release of OpenTelemetry Node.js Community Agent"
+          tag: ${{ needs.release-pr.outputs.tag_name }}
+  

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "include-v-in-tag": true,
+    "bootstrap-sha": "0cf39da967f6bfa22be9ce619655d5eaa492d048",
     "packages": {
         ".": {
             "release-type": "node",


### PR DESCRIPTION
Fixes: CORE-200

#33  added the `"include-component-in-tag": false` release-please configuration which makes it look as a new release to release please. Adding bootstrap sha makes the release notes for this initial commit right (instead of including all commits from start of repo)