### PR TITLE
fix: goggle pubsub start new trace on consume retry

### DIFF
--- a/src/instrumentations/googlepubsub/pubsub-instrumentation.ts
+++ b/src/instrumentations/googlepubsub/pubsub-instrumentation.ts
@@ -6,6 +6,7 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
   type ShimWrapped,
+  InstrumentationNodeModuleFile,
 } from "@opentelemetry/instrumentation";
 import { VERSION } from "../../version";
 import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
@@ -89,7 +90,27 @@ export class PubSubInstrumentation extends InstrumentationBase<PubSubInstrumenta
               (self as any)._unwrap(SubscriptionProto, "on");
             }
           } catch { }
-        }
+        },
+        [new InstrumentationNodeModuleFile(
+          '@google-cloud/pubsub/build/src/exponential-retry.js',
+          ['*'],
+          (moduleExports: any) => {
+            if (!moduleExports) return moduleExports;
+            const ExponentialRetryProto = (moduleExports as any).ExponentialRetry?.prototype;
+            if(ExponentialRetryProto) {
+              (self as any)._wrap(ExponentialRetryProto, "retryLater", self._createRetryLaterWrap());
+            }
+            return moduleExports;
+          },
+          (moduleExports: any) => {
+            if (!moduleExports) return moduleExports;
+            const ExponentialRetryProto = (moduleExports as any).ExponentialRetry?.prototype;
+            if(ExponentialRetryProto) {
+              (self as any)._unwrap(ExponentialRetryProto, "retryLater");
+            }
+            return moduleExports;
+          }
+        )]
       ),
     ];
   }
@@ -356,6 +377,19 @@ export class PubSubInstrumentation extends InstrumentationBase<PubSubInstrumenta
       } as any;
     };
   }
+
+  private _createRetryLaterWrap() {
+    const self = this;
+    return function (original: (...args: any[]) => any): any {
+      return function wrapped(this: any, ...args: any[]) {
+        // start a new trace for a retry.
+        // if not - we can retry forever and create infinite traces.
+        context.with(ROOT_CONTEXT, () => {
+          return original.apply(this, args);
+        });
+      }
+    }
+  }  
 }
 
 function safeGetTopicName(topicInstance: any): string | undefined {


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-847

The way google pubsub works is by setting a grpc stream with timeout of 15min. when the currently grpc stream ends, the sdk will retry it, which causes infinite traces since each stream end is in the same trace as the previous one.

This PR makes it so that every new retry is a new trace


#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
@google-cloud/pubsub start a new trace for every retry of grpc consume stream, so the traces are finite and bounded
```
