### PR TITLE
CORE-826: Update axios in node-14 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Since otel stopped supporting node 14 and stopped maintaining the sdk v1 version
 If it ever needs to be updated, login to ecr and publish a new version:
 
 ```
-export NEW_VERSION="v0.0.15"
+export NEW_VERSION="v0.0.17"
 export ECR_REPO_NODEJS_COMMUNITY="public.ecr.aws/odigos/agents/nodejs-community-14"
 
 # Stable release: tag version + latest
@@ -21,4 +21,11 @@ docker buildx build \
   --tag "${ECR_REPO_NODEJS_COMMUNITY}:latest" \
   --push \
   .
+```
+
+Then push the new git tag on this branch:
+
+```
+git tag nodejs-community-14/$NEW_VERSION
+git push upstream nodejs-community-14/$NEW_VERSION
 ```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@opentelemetry/instrumentation-fastify": "0.44.2",
     "@opentelemetry/instrumentation-fs": "0.19.1",
     "@opentelemetry/instrumentation-generic-pool": "0.43.1",
-    "@opentelemetry/instrumentation-graphql": "0.47.1",    
+    "@opentelemetry/instrumentation-graphql": "0.47.1",
     "@opentelemetry/instrumentation-grpc": "0.57.1",
     "@opentelemetry/instrumentation-hapi": "0.45.2",
     "@opentelemetry/instrumentation-http": "0.57.1",
@@ -56,7 +56,7 @@
     "@opentelemetry/resources": "1.30.1",
     "@opentelemetry/sdk-trace-node": "1.30.1",
     "@opentelemetry/semantic-conventions": "1.40.0",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "semver": "^7.6.2",
     "uuidv7": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,14 +704,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.13.5:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.6.tgz#c3f92da917dc209a15dd29936d20d5089b6b6c98"
-  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
+axios@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -1020,10 +1020,10 @@ protobufjs@^7.3.0:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 require-in-the-middle@^7.1.1:
   version "7.3.0"


### PR DESCRIPTION
#### What this PR does / why we need it:
Update nodejs-enterprise-14 to v0.0.17 which includes a bump to fix [[CVE-2026-40175](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)](https://github.com/advisories/GHSA-fvcv-3m26-pcqx)

https://github.com/odigos-io/odigos-enterprise/pull/2602
https://github.com/odigos-io/ebpf-nodejs-instrumentation/pull/290
https://github.com/odigos-io/odigos/pull/4618

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
