### PR TITLE
feat: support collecting all http headers with a start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odigos/opentelemetry-node",
-  "version": "0.0.14",
+  "version": "0.0.0",
   "description": "Odigos distribution of OpenTelemetry for Node.js",
   "main": "build/src/autoinstrumentation.js",
   "repository": "https://github.com/odigos-io/opentelemetry-node",

--- a/src/autoinstrumentation.ts
+++ b/src/autoinstrumentation.ts
@@ -39,7 +39,6 @@ import {
 import { OdigosProcessDetector, PROCESS_VPID } from "./OdigosProcessDetector";
 import { idGeneratorFromConfig } from "./id-generator";
 import { OdigosHeadSampler } from "./sampler";
-import { PubSubMessageHookInfo } from "./instrumentations/googlepubsub/types";
 import { InstrumentationLibraryConfigFunction } from "./instrumentations/config";
 
 const serviceInstanceId = uuidv7();

--- a/src/instrumentations/config.ts
+++ b/src/instrumentations/config.ts
@@ -2,9 +2,9 @@ import { RemoteConfig } from "../opamp";
 import { Instrumentation, InstrumentationConfig } from "@opentelemetry/instrumentation";
 import { PubSubInstrumentation } from "./googlepubsub/pubsub-instrumentation";
 
-import type { HttpInstrumentationConfig } from "@opentelemetry/instrumentation-http";
+import { getAllHeadersInstrumentationConfig, getHttpHeadersFromRemoteConfig, getSpecificHttpHeadersInstrumentationConfig, isCollectingAllHttpHeaders } from "./header-collection";
 
-export type InstrumentationLibraryConfigFunction = (libraryName: string, config: RemoteConfig | undefined) => InstrumentationConfig;
+export type InstrumentationLibraryConfigFunction = (libraryName: string, agentConfig: RemoteConfig | undefined, currentInstrumentationConfig: InstrumentationConfig | undefined) => InstrumentationConfig;
 
 export type InstrumentationFactory = (config: InstrumentationConfig | undefined) => Instrumentation;
 
@@ -87,23 +87,17 @@ export const instrumentationLibraryManifests: Map<string, InstrumentationLibrary
         instrumentationNpmPackage: "@opentelemetry/instrumentation-http",
         import: "HttpInstrumentation",
         config: (_: string, config: RemoteConfig | undefined): InstrumentationConfig => {
-            const headerKeys = config?.containerConfig?.traces?.headersCollection?.httpHeaderKeys;
-            if (!headerKeys) {
+            const headerKeys = getHttpHeadersFromRemoteConfig(config);
+            if (!headerKeys || headerKeys.length === 0) {
                 return {};
             }
-
-            return {
-                headersToSpanAttributes: {
-                    server: {
-                        requestHeaders: headerKeys,
-                        responseHeaders: headerKeys,
-                    },
-                    client: {
-                        requestHeaders: headerKeys,
-                        responseHeaders: headerKeys,
-                    },
-                },
-            } as HttpInstrumentationConfig;
+       
+            const isCollectingAllHeaders = isCollectingAllHttpHeaders(headerKeys);
+            if (isCollectingAllHeaders) {
+                return getAllHeadersInstrumentationConfig();
+            } else {
+                return getSpecificHttpHeadersInstrumentationConfig(headerKeys);
+            }
         },
     }],
     ["@opentelemetry/instrumentation-ioredis", {

--- a/src/instrumentations/header-collection.ts
+++ b/src/instrumentations/header-collection.ts
@@ -1,0 +1,64 @@
+import { HttpInstrumentationConfig } from "@opentelemetry/instrumentation-http";
+import { RemoteConfig } from "../opamp";
+import { Span } from "@opentelemetry/api";
+import { ClientRequest, IncomingMessage, ServerResponse } from "http";
+
+export const getHttpHeadersFromRemoteConfig = (remoteConfig: RemoteConfig | undefined): string[] | undefined => {
+    return remoteConfig?.containerConfig?.traces?.headersCollection?.httpHeaderKeys;
+}
+
+export const isCollectingAllHttpHeaders = (headerKeys: string[] | undefined): boolean => {
+    return Array.isArray(headerKeys) && headerKeys.some((k) => k === "*");
+}
+
+export const getSpecificHttpHeadersInstrumentationConfig = (headerKeys: string[]): HttpInstrumentationConfig => {
+    return {
+        headersToSpanAttributes: {
+            server: {
+                requestHeaders: headerKeys,
+                responseHeaders: headerKeys,
+            },
+            client: {
+                requestHeaders: headerKeys,
+                responseHeaders: headerKeys,
+            },
+        },
+    } as HttpInstrumentationConfig;
+}
+
+type GetHeader = (name: string) => number | string | string[] | undefined;
+
+const recordHttpHeaders = (span: Span, type: 'request' | 'response', headerNames: string[], getHeader: GetHeader) => {
+    for (const name of headerNames) {
+        const value = getHeader(name);
+        if (value) {
+            const key = `http.${type}.headers.${name.toLowerCase()}`;
+            if (typeof value === 'string') {
+                span.setAttribute(key, [value]);
+            } else if (Array.isArray(value)) {
+                span.setAttribute(key, value);
+            } else {
+                span.setAttribute(key, [value]);
+            }
+        }
+    }
+}
+
+export const getAllHeadersInstrumentationConfig = (): HttpInstrumentationConfig => {
+    return {
+        applyCustomAttributesOnSpan: (span: Span, request: ClientRequest | IncomingMessage, response: IncomingMessage | ServerResponse) => {
+            
+            if (request instanceof ClientRequest) {
+                recordHttpHeaders(span, 'request', request.getHeaderNames(), (name) => request.getHeader(name));
+            } else if (request instanceof IncomingMessage) {
+                recordHttpHeaders(span, 'request', Object.keys(request.headers), (name) => request.headers[name]);
+            }
+
+            if (response instanceof ServerResponse) {
+                recordHttpHeaders(span, 'response', response.getHeaderNames(), (name) => response.getHeader(name));
+            } else if (response instanceof IncomingMessage) {
+                recordHttpHeaders(span, 'response', Object.keys(response.headers), (name) => response.headers[name]);
+            }
+        }
+    } as HttpInstrumentationConfig;
+}

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -41,9 +41,9 @@ export class InstrumentationLibraries {
         // set global tracer provider to record traces from 3rd party instrumented libraries
         for (const [_, instrumentationLibrary] of this.instrumentationLibraries.entries()) {
             const resolvedConfig = resolveBaseConfig(instrumentationLibrary.manifest, remoteConfig);
-            const additionalConfig = instrumentationLibrary.additionalConfig?.(instrumentationLibrary.manifest.instrumentationNpmPackage, remoteConfig);
+            const additionalConfig = instrumentationLibrary.additionalConfig?.(instrumentationLibrary.manifest.instrumentationNpmPackage, remoteConfig, resolvedConfig);
             const effectiveConfig = { ...resolvedConfig, ...additionalConfig };
-            
+
             instrumentationLibrary.instrumentationInstance.setConfig(effectiveConfig ?? {});
             instrumentationLibrary.instrumentationInstance.setTracerProvider(tracerProviderInUse);
         }

--- a/src/instrumentations/utils.ts
+++ b/src/instrumentations/utils.ts
@@ -29,7 +29,7 @@ export const createInstrumentationLibraryInstance = (
 ): Instrumentation | undefined => {
 
     const instrumentationConfig = resolveBaseConfig(manifest, remoteConfig);
-    const additionalConfig = additionalConfigFn?.(manifest.instrumentationNpmPackage, remoteConfig) ?? {};
+    const additionalConfig = additionalConfigFn?.(manifest.instrumentationNpmPackage, remoteConfig, instrumentationConfig) ?? {};
 
     const effectiveConfig = { ...instrumentationConfig, ...additionalConfig };
 
@@ -46,26 +46,13 @@ export const createInstrumentationLibraryInstance = (
     }
 }
 
-export const resolveAdditionalConfig = (
-    additionalConfigFn: InstrumentationLibraryConfigFunction | undefined, 
-    manifest: InstrumentationLibraryManifest, 
-    remoteConfig?: RemoteConfig
-): InstrumentationConfig => {
-    if (!additionalConfigFn) {
-        return {};
-    }
-
-    const additionalConfig = additionalConfigFn(manifest.instrumentationNpmPackage, remoteConfig);
-    return additionalConfig ?? {};
-}
-
 export const resolveBaseConfig = (manifest: InstrumentationLibraryManifest, remoteConfig: RemoteConfig | undefined): InstrumentationConfig => {
     if (!manifest.config) {
         return {}
     }
 
     if (typeof manifest.config === "function") {
-        return manifest.config(manifest.instrumentationNpmPackage, remoteConfig);
+        return manifest.config(manifest.instrumentationNpmPackage, remoteConfig, undefined);
     } else {
         return manifest.config;
     }


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-913

nodejs agent supports collecting http headers, but just as a list of header names to collect. This PR adds support for collecting all http header by setting a `*`

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
nodejs agents: support collecting all http headers by setting a '*' in the header names
```
