### PR TITLE
feat: head-sampling noisy operation rules

### DIFF
--- a/src/autoinstrumentation.ts
+++ b/src/autoinstrumentation.ts
@@ -11,7 +11,7 @@ import {
   W3CBaggagePropagator,
   W3CTraceContextPropagator,
 } from "@opentelemetry/core";
-import { OpAMPClientHttp, RemoteConfig, SdkHealthStatus } from "./opamp";
+import { OpAMPClientHttp, RemoteConfig } from "./opamp";
 import {
   ATTR_SERVICE_INSTANCE_ID,
   ATTR_TELEMETRY_SDK_LANGUAGE,

--- a/src/autoinstrumentation.ts
+++ b/src/autoinstrumentation.ts
@@ -115,12 +115,12 @@ export const startOpenTelemetryAgent = (distroName: string, opampServerHost: str
         const idGenerator = idGeneratorFromConfig(idGeneratorConfig);
 
         var sampler: Sampler | undefined = undefined;
-        // const headSamplingConfig = remoteConfig.containerConfig?.traces?.headSampling;
-        // if (headSamplingConfig) {
-        //   sampler = new ParentBasedSampler({
-        //     root: new OdigosHeadSampler(headSamplingConfig),
-        //   });
-        // }
+        const headSamplingConfig = remoteConfig.containerConfig?.traces?.headSampling;
+        if (headSamplingConfig) {
+          sampler = new ParentBasedSampler({
+            root: new OdigosHeadSampler(headSamplingConfig),
+          });
+        }
 
         const nodeTracerProvider = new NodeTracerProvider({
           sampler,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,8 +23,34 @@ export interface HeadersCollectionConfig {
     httpHeaderKeys: string[];
 }
 
+export interface HeadSamplingOperationMatcher {
+    httpServer?: HttpSamplingOperationMatcherServer;
+    httpClient?: HttpSamplingOperationMatcherClient;
+}
+
+export interface HttpSamplingOperationMatcherServer {
+    route?: string;
+    routePrefix?: string;
+    method?: string;
+}
+
+export interface HttpSamplingOperationMatcherClient {
+    serverAddress?: string;
+    templatedPath?: string;
+    templatedPathPrefix?: string;
+    method?: string;
+}
+
+export interface NoisyOperationSamplingConfig {
+    id: string;
+    name?: string;
+    disabled?: boolean;
+    operation?: HeadSamplingOperationMatcher;
+    percentageAtMost?: number;
+}
+
 export interface HeadSamplingConfig {
-    // Noisy operations head sampling will be added here.
+    noisyOperations: NoisyOperationSamplingConfig[];
 }
 
 export interface TracesConfig {

--- a/src/sampler/http-client.ts
+++ b/src/sampler/http-client.ts
@@ -1,0 +1,43 @@
+import { HttpSamplingOperationMatcherClient } from "../config";
+import {
+    ParsedHttpClientAttributes,
+    compareHttpMethod,
+    comparePathToTemplate,
+} from "./utils";
+
+function matchTemplatedPath(parsed: ParsedHttpClientAttributes, ruleTemplatedPath: string | undefined, ruleTemplatedPathPrefix: string | undefined): boolean {
+    if (!ruleTemplatedPath && !ruleTemplatedPathPrefix) {
+        return true;
+    }
+
+    if (parsed.templatedPath) {
+        return comparePathToTemplate(parsed.templatedPath, ruleTemplatedPath, ruleTemplatedPathPrefix);
+    }
+
+    // TODO: extract the path from either url.full or http.target attributes and compare to the rule.
+    return false;
+}
+
+function matchServerAddress(spanServerAddress: string | undefined, ruleServerAddress: string): boolean {
+    if (!spanServerAddress) {
+        return false;
+    }
+    return spanServerAddress === ruleServerAddress;
+}
+
+export function matchHttpClientRule(matcherConfig: HttpSamplingOperationMatcherClient, parsed: ParsedHttpClientAttributes): boolean {
+    if (matcherConfig.method && !compareHttpMethod(parsed.method, matcherConfig.method)) {
+        return false;
+    }
+
+    if (matcherConfig.serverAddress && !matchServerAddress(parsed.serverAddress, matcherConfig.serverAddress)) {
+        return false;
+    }
+
+    if ((matcherConfig.templatedPath || matcherConfig.templatedPathPrefix) &&
+        !matchTemplatedPath(parsed, matcherConfig.templatedPath, matcherConfig.templatedPathPrefix)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/sampler/http-server.ts
+++ b/src/sampler/http-server.ts
@@ -1,0 +1,36 @@
+import { HttpSamplingOperationMatcherServer } from "../config";
+import {
+    ParsedHttpServerAttributes,
+    compareHttpMethod,
+    compareHttpRoute,
+    comparePathToTemplate,
+} from "./utils";
+
+function matchHttpRoute(parsed: ParsedHttpServerAttributes, ruleRouteExact: string | undefined, ruleRoutePrefix: string | undefined ): boolean {
+    if (!ruleRouteExact && !ruleRoutePrefix) {
+        return true;
+    }
+
+    if (parsed.route) {
+        return compareHttpRoute(parsed.route, ruleRouteExact, ruleRoutePrefix);
+    }
+
+    if (parsed.path) {
+        return comparePathToTemplate(parsed.path, ruleRouteExact, ruleRoutePrefix);
+    }
+
+    return false;
+}
+
+export function matchHttpServerRule(matcherConfig: HttpSamplingOperationMatcherServer, parsed: ParsedHttpServerAttributes): boolean {
+    if (matcherConfig.method && !compareHttpMethod(parsed.method, matcherConfig.method)) {
+        return false;
+    }
+
+    if ((matcherConfig.route || matcherConfig.routePrefix) &&
+        !matchHttpRoute(parsed, matcherConfig.route, matcherConfig.routePrefix)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/sampler/index.ts
+++ b/src/sampler/index.ts
@@ -1,15 +1,105 @@
 import { Attributes, Context, Link, SpanKind } from "@opentelemetry/api";
-import { Sampler, SamplingDecision, SamplingResult, TraceIdRatioBasedSampler } from "@opentelemetry/sdk-trace-base";
-import { HeadSamplingConfig } from "../config";
+import { Sampler, SamplingDecision, SamplingResult } from "@opentelemetry/sdk-trace-base";
+import { HeadSamplingConfig, NoisyOperationSamplingConfig } from "../config";
+import { matchHttpServerRule } from "./http-server";
+import { matchHttpClientRule } from "./http-client";
+import { parseHttpServerAttributes, parseHttpClientAttributes } from "./utils";
+import { samplingDecisionByPercentage } from "./percentage";
 
 export class OdigosHeadSampler implements Sampler {
 
+    private serviceRules: NoisyOperationSamplingConfig[];
+    private httpServerRules: NoisyOperationSamplingConfig[];
+    private httpClientRules: NoisyOperationSamplingConfig[];
 
     constructor(config: HeadSamplingConfig) {
+        this.serviceRules = [];
+        this.httpServerRules = [];
+        this.httpClientRules = [];
+
+        for (const rule of config.noisyOperations) {
+            if (rule.disabled) {
+                continue;
+            }
+
+            if (!rule.operation) {
+                this.serviceRules.push(rule);
+            } else if (rule.operation.httpServer) {
+                this.httpServerRules.push(rule);
+            } else if (rule.operation.httpClient) {
+                this.httpClientRules.push(rule);
+            }
+        }
     }
 
     shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: Attributes, links: Link[]): SamplingResult {
-        return { decision: SamplingDecision.RECORD_AND_SAMPLED };
+        const matchedRules: NoisyOperationSamplingConfig[] = [];
+        for (const rule of this.serviceRules) {
+            matchedRules.push(rule);
+        }
+
+        switch (spanKind) {
+            case SpanKind.SERVER:
+                this.matchHttpServerRules(attributes, matchedRules);
+                break;
+            case SpanKind.CLIENT:
+                this.matchHttpClientRules(attributes, matchedRules);
+                break;
+        }
+
+        // no rules matched, so we keep it.
+        if (matchedRules.length === 0) {
+            return { decision: SamplingDecision.RECORD_AND_SAMPLED };
+        }
+
+        // find the rule with minimum percentage, default if not set is 0
+        const minPercentageRule = this.findMinPercentageRule(matchedRules);
+        const percentage = minPercentageRule.percentageAtMost ?? 0;
+
+        return {
+            decision: samplingDecisionByPercentage(traceId, percentage),
+        };
+    }
+
+    private matchHttpServerRules(attributes: Attributes, matchedRules: NoisyOperationSamplingConfig[]): void {
+        const parsed = parseHttpServerAttributes(attributes);
+        if (!parsed) return;
+        for (const rule of this.httpServerRules) {
+            if (matchHttpServerRule(rule.operation!.httpServer!, parsed)) {
+                matchedRules.push(rule);
+            }
+        }
+    }
+
+    private matchHttpClientRules(attributes: Attributes, matchedRules: NoisyOperationSamplingConfig[]): void {
+        const parsed = parseHttpClientAttributes(attributes);
+        if (!parsed) return;
+        for (const rule of this.httpClientRules) {
+            if (matchHttpClientRule(rule.operation!.httpClient!, parsed)) {
+                matchedRules.push(rule);
+            }
+        }
+    }
+
+    // givin all the head sampling rules that matched, find the rule with minimum percentage.
+    // percentage undefined or 0 is considered as 0.
+    findMinPercentageRule(rules: NoisyOperationSamplingConfig[]): NoisyOperationSamplingConfig {
+        let minPercentage: NoisyOperationSamplingConfig | undefined = undefined;
+        for (const rule of rules) {
+            if (rule.percentageAtMost === undefined || rule.percentageAtMost === 0) {
+                // early return if we hit the minimum percentage.
+                return rule;
+            }
+
+            if (minPercentage === undefined) {
+                // set first time
+                minPercentage = rule;
+            } else if (rule.percentageAtMost < minPercentage.percentageAtMost!) {
+                // found a rule with lower percentage.
+                minPercentage = rule;
+            }
+        }
+        return minPercentage!;
     }
 
     toString(): string {

--- a/src/sampler/percentage.ts
+++ b/src/sampler/percentage.ts
@@ -1,0 +1,39 @@
+// Computes a deterministic trace percentage from a traceId using the
+// OpenTelemetry consistent probability sampling algorithm.
+// https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/#consistent-sampling-decision
+//
+// This is the same algorithm used by the OpenTelemetry Collector
+// (github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling),
+// so both the SDK sampler and the Collector will derive the same percentage
+// for a given traceId, producing consistent sampling decisions.
+
+import { SamplingDecision } from "@opentelemetry/sdk-trace-base";
+
+// 2^56 — the number of distinct randomness values (56 bits of entropy).
+const MAX_ADJUSTED_COUNT = 2 ** 56;
+
+// 56 bits = 7 bytes = 14 hex characters (bytes 9-15 of the TraceID).
+const RANDOMNESS_HEX_DIGITS = 14;
+
+/**
+ * Derives a deterministic percentage in [0, 100] from a hex-encoded traceId.
+ * Extracts 56 bits of randomness from the second half of the TraceID
+ * (as specified by W3C Trace Context Level 2) and maps them linearly to [0, 100].
+ */
+function traceIdToPercentage(traceId: string): number {
+    const randomnessHex = traceId.slice(-RANDOMNESS_HEX_DIGITS);
+    // Precision loss for integers > 2^53 is negligible for a sampling percentage.
+    const randomness = parseInt(randomnessHex, 16);
+    return (randomness / MAX_ADJUSTED_COUNT) * 100;
+}
+
+/**
+ * Returns a sampling decision by comparing the trace's deterministic percentage
+ * against the configured rule percentage.
+ */
+export function samplingDecisionByPercentage(traceId: string, rulePercentage: number): SamplingDecision {
+    const tracePercentage = traceIdToPercentage(traceId);
+    return tracePercentage < rulePercentage
+        ? SamplingDecision.RECORD_AND_SAMPLED
+        : SamplingDecision.NOT_RECORD;
+}

--- a/src/sampler/utils.ts
+++ b/src/sampler/utils.ts
@@ -1,0 +1,135 @@
+import { Attributes } from "@opentelemetry/api";
+import { ATTR_HTTP_ROUTE, ATTR_HTTP_REQUEST_METHOD, ATTR_SERVER_ADDRESS, ATTR_URL_PATH } from "@opentelemetry/semantic-conventions";
+import { SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_TARGET, SEMATTRS_HTTP_ROUTE, SEMATTRS_NET_PEER_NAME } from "@opentelemetry/semantic-conventions";
+
+const ATTR_URL_TEMPLATE = "url.template";
+
+export const getHttpMethodFromAttributes = (attributes: Attributes): string | undefined => {
+    const methodNew = attributes[ATTR_HTTP_REQUEST_METHOD];
+    if (methodNew) {
+        return methodNew.toString();
+    }
+
+    const methodOld = attributes[SEMATTRS_HTTP_METHOD];
+    if (methodOld) {
+        return methodOld.toString();
+    }
+
+    return undefined;
+}
+
+export const getHttpRouteFromAttributes = (attributes: Attributes): string | undefined => {
+    const route = attributes[ATTR_HTTP_ROUTE];
+    if (route) {
+        return route.toString();
+    }
+
+    const routeOld = attributes[SEMATTRS_HTTP_ROUTE];
+    if (routeOld) {
+        return routeOld.toString();
+    }
+
+    return undefined;
+}
+
+export const getHttpPathFromAttributes = (attributes: Attributes): string | undefined => {
+    const pathNew = attributes[ATTR_URL_PATH];
+    if (pathNew) {
+        return pathNew.toString();
+    }
+
+    const httpTargetLegacy = attributes[SEMATTRS_HTTP_TARGET];
+    if (httpTargetLegacy) {
+        const httpTarget = httpTargetLegacy.toString();
+        if (httpTarget.includes('?')) {
+            return httpTarget.split('?')[0];
+        } else {
+            return httpTarget;
+        }
+    }
+
+    return undefined;
+}
+
+export const getHttpTemplatedPathFromAttributes = (attributes: Attributes): string | undefined => {
+    const urlTemplate = attributes[ATTR_URL_TEMPLATE];
+    if (urlTemplate) {
+        return urlTemplate.toString();
+    }
+
+    return undefined;
+}
+
+export const getServerAddressFromAttributes = (attributes: Attributes): string | undefined => {
+    const serverAddress = attributes[ATTR_SERVER_ADDRESS];
+    if (serverAddress) {
+        return serverAddress.toString();
+    }
+
+    const netPeerName = attributes[SEMATTRS_NET_PEER_NAME];
+    if (netPeerName) {
+        return netPeerName.toString();
+    }
+
+    return undefined;
+}
+
+export interface ParsedHttpServerAttributes {
+    method: string;
+    route?: string;
+    path?: string;
+}
+
+export const parseHttpServerAttributes = (attributes: Attributes): ParsedHttpServerAttributes | undefined => {
+    const method = getHttpMethodFromAttributes(attributes);
+    if (!method) {
+        return undefined;
+    }
+    return {
+        method,
+        route: getHttpRouteFromAttributes(attributes),
+        path: getHttpPathFromAttributes(attributes),
+    };
+}
+
+export interface ParsedHttpClientAttributes {
+    method: string;
+    templatedPath?: string;
+    serverAddress?: string;
+}
+
+export const parseHttpClientAttributes = (attributes: Attributes): ParsedHttpClientAttributes | undefined => {
+    const method = getHttpMethodFromAttributes(attributes);
+    if (!method) {
+        return undefined;
+    }
+    return {
+        method,
+        templatedPath: getHttpTemplatedPathFromAttributes(attributes),
+        serverAddress: getServerAddressFromAttributes(attributes),
+    };
+}
+
+export const compareHttpMethod = (method: string, ruleMethod: string): boolean => {
+    return method.toUpperCase() === ruleMethod.toUpperCase();
+}
+
+export const compareHttpRoute = (route: string, ruleRouteExact: string | undefined, ruleRoutePrefix: string | undefined ): boolean => {
+    if (ruleRouteExact && route !== ruleRouteExact) {
+        return false;
+    }
+    if (ruleRoutePrefix && !route.startsWith(ruleRoutePrefix)) {
+        return false;
+    }
+    return true;
+}
+
+export const comparePathToTemplate = (path: string, ruleTemplateExact: string | undefined, ruleTemplatePrefix: string | undefined): boolean => {
+    if (ruleTemplateExact && path !== ruleTemplateExact) {
+        return false;
+    }
+    if (ruleTemplatePrefix && !path.startsWith(ruleTemplatePrefix)) {
+        return false;
+    }
+    return true;
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-914

Implement head sampling based on the remote config noisy operations.

Check each rule, and pick the one with least percentage, then apply sampling based on it.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
head sampling for noisy operations
```
