### PR TITLE
feat: populate trace state with sampling props

### DIFF
--- a/src/autoinstrumentation.ts
+++ b/src/autoinstrumentation.ts
@@ -55,7 +55,7 @@ export const createNativeCommunitySpanProcessor = (): SpanProcessor => {
 // this function is meant to be called by the specific agent implementation.
 // it allows the agent to provide its own span processor, depending on the
 // agent implementation (for example - eBPF span processor for enterprise agent)
-export const startOpenTelemetryAgent = (distroName: string, opampServerHost: string, spanProcessor: SpanProcessor, additionalConfigs: Record<string, InstrumentationLibraryConfigFunction> | undefined): InstrumentationLibrariesTracerProviderSetter | undefined => {
+export const startOpenTelemetryAgent = (distroName: string, opampServerHost: string, spanProcessorExporting: SpanProcessor, additionalConfigs: Record<string, InstrumentationLibraryConfigFunction> | undefined): InstrumentationLibrariesTracerProviderSetter | undefined => {
   if (!opampServerHost) {
     diag.error(
       "Missing required environment variables ODIGOS_OPAMP_SERVER_HOST"
@@ -126,7 +126,7 @@ export const startOpenTelemetryAgent = (distroName: string, opampServerHost: str
           sampler,
           resource,
           idGenerator,
-          spanProcessors: [spanProcessor],
+          spanProcessors: [spanProcessorExporting],
         });
         tracerProvider = nodeTracerProvider;
       }
@@ -144,7 +144,7 @@ export const startOpenTelemetryAgent = (distroName: string, opampServerHost: str
       diag.info("Shutting down OpenTelemetry SDK and OpAMP client");
       await Promise.all([
         opampClient.shutdown(shutdownReason),
-        spanProcessor.shutdown(),
+        spanProcessorExporting.shutdown(),
       ]);
     } catch (err) {
       diag.error("Error shutting down OpenTelemetry SDK and OpAMP client", err);

--- a/src/sampler/index.ts
+++ b/src/sampler/index.ts
@@ -1,4 +1,4 @@
-import { Attributes, Context, Link, SpanKind } from "@opentelemetry/api";
+import { Attributes, Context, createTraceState, Link, SpanKind } from "@opentelemetry/api";
 import { Sampler, SamplingDecision, SamplingResult } from "@opentelemetry/sdk-trace-base";
 import { HeadSamplingConfig, NoisyOperationSamplingConfig } from "../config";
 import { matchHttpServerRule } from "./http-server";
@@ -54,11 +54,15 @@ export class OdigosHeadSampler implements Sampler {
 
         // find the rule with minimum percentage, default if not set is 0
         const minPercentageRule = this.findMinPercentageRule(matchedRules);
-        const percentage = minPercentageRule.percentageAtMost ?? 0;
+        const keepPercentage = minPercentageRule.percentageAtMost ?? 0;
+        const percentageTwoDecimalPlaces = Math.round(keepPercentage * 100) / 100;
 
-        return {
-            decision: samplingDecisionByPercentage(traceId, percentage),
-        };
+        const decision = samplingDecisionByPercentage(traceId, keepPercentage);
+        // c means category, n means noise.
+        // dr means deciding rule, p means percentage, id means deciding rule id.
+        const traceStateString = `odigos=c:n;dr.p:${percentageTwoDecimalPlaces};dr.id:${minPercentageRule.id}`;
+        const traceState = createTraceState(traceStateString);
+        return { decision, traceState };
     }
 
     private matchHttpServerRules(attributes: Attributes, matchedRules: NoisyOperationSamplingConfig[]): void {

--- a/src/sampler/percentage.ts
+++ b/src/sampler/percentage.ts
@@ -31,9 +31,20 @@ function traceIdToPercentage(traceId: string): number {
  * Returns a sampling decision by comparing the trace's deterministic percentage
  * against the configured rule percentage.
  */
-export function samplingDecisionByPercentage(traceId: string, rulePercentage: number): SamplingDecision {
-    const tracePercentage = traceIdToPercentage(traceId);
-    return tracePercentage < rulePercentage
-        ? SamplingDecision.RECORD_AND_SAMPLED
-        : SamplingDecision.NOT_RECORD;
+export function samplingDecisionByPercentage(traceId: string, keepPercentage: number): SamplingDecision {
+
+    // if rulePercentage is 0, we always not record and sample.
+    // if rulePercentage is 100, we always record and sample.
+    // everything is between is linearly mapped to the decision.
+    switch (keepPercentage) {
+        case 0:
+            return SamplingDecision.NOT_RECORD;
+        case 100:
+            return SamplingDecision.RECORD_AND_SAMPLED;
+        default:
+            const tracePercentage = traceIdToPercentage(traceId);
+            return tracePercentage < keepPercentage
+                ? SamplingDecision.RECORD_AND_SAMPLED
+                : SamplingDecision.NOT_RECORD;
+    }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixed: CORE-914

Add trace state to spans after sampling so we can populate sampling attributes

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
add trace state with sampling attributes
```
