### PR TITLE
fix: upgrade axios to ^1.15.0 to resolve CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@opentelemetry/resources": "1.25.1",
     "@opentelemetry/sdk-trace-node": "1.25.1",
     "@opentelemetry/semantic-conventions": "1.25.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "semver": "^7.6.2",
     "uuidv7": "^1.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -667,14 +667,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.13.5:
-  version "1.13.6"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.6.tgz#c3f92da917dc209a15dd29936d20d5089b6b6c98"
-  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
+axios@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
-    proxy-from-env "^1.1.0"
+    proxy-from-env "^2.1.0"
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -983,10 +983,10 @@ protobufjs@^7.3.0:
     "@types/node" ">=13.7.0"
     long "^5.0.0"
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 require-in-the-middle@^7.1.1:
   version "7.3.0"


### PR DESCRIPTION
## Summary
fixes RUN-717
- Upgrades axios from `^1.13.5` to `^1.15.0` (resolves to 1.15.0 in yarn.lock)
- Fixes 3 CVEs found in v1.17.10 vulnerability scan

| CVE | Severity | Description | Fixed in |
|-----|----------|-------------|----------|
| GHSA-43fc-jf86-j433 | **High** | DoS via `__proto__` key in mergeConfig | 1.13.5 |
| GHSA-fvcv-3m26-pcqx | Medium | Cloud metadata exfiltration via header injection | 1.15.0 |
| GHSA-3p68-rc4w-qgx5 | Medium | SSRF via NO_PROXY hostname normalization bypass | 1.15.0 |

## Context

Customer on Odigos v1.17.10 needs these fixes. Enterprise odiglet Dockerfile consumes `nodejs-enterprise:v0.0.14`. This patch can be tagged as `v0.0.15`.

Depends on: odigos-io/odigos-enterprise#2632 (Dockerfile update)

```release-note
fix: resolve axios CVEs in nodejs agent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)