### PR TITLE
feat: support dry run config option in head sampling

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -50,6 +50,14 @@ export interface NoisyOperationSamplingConfig {
 }
 
 export interface HeadSamplingConfig {
+
+	// If true, the sampling decision will be made in dry-run mode.
+	// When dry-run is enabled, the sampling decision will be made but the trace will not be dropped.
+	// This is useful to evaluate the sampling decision before actually committing to it.
+    dryRun?: boolean;
+
+    // configuration for the noisy operations.
+    // if not specified, no noisy operations will be applied.
     noisyOperations: NoisyOperationSamplingConfig[];
 }
 

--- a/src/sampler/index.ts
+++ b/src/sampler/index.ts
@@ -11,6 +11,7 @@ export class OdigosHeadSampler implements Sampler {
     private serviceRules: NoisyOperationSamplingConfig[];
     private httpServerRules: NoisyOperationSamplingConfig[];
     private httpClientRules: NoisyOperationSamplingConfig[];
+    private dryRun: boolean;
 
     constructor(config: HeadSamplingConfig) {
         this.serviceRules = [];
@@ -30,6 +31,7 @@ export class OdigosHeadSampler implements Sampler {
                 this.httpClientRules.push(rule);
             }
         }
+        this.dryRun = config.dryRun ?? false;
     }
 
     shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: Attributes, links: Link[]): SamplingResult {
@@ -60,8 +62,16 @@ export class OdigosHeadSampler implements Sampler {
         const decision = samplingDecisionByPercentage(traceId, keepPercentage);
         // c means category, n means noise.
         // dr means deciding rule, p means percentage, id means deciding rule id.
-        const traceStateString = `odigos=c:n;dr.p:${percentageTwoDecimalPlaces};dr.id:${minPercentageRule.id}`;
+        // dry means dryrun
+        const dryRunString = this.dryRun ? ';dry:' + (decision === SamplingDecision.RECORD_AND_SAMPLED ? 't' : 'f') : '';
+        const traceStateString = `odigos=c:n;dr.p:${percentageTwoDecimalPlaces};dr.id:${minPercentageRule.id}${dryRunString}`;
         const traceState = createTraceState(traceStateString);
+
+        // if dry run is enabled, do not drop the trace (but keep the trace state to record what would have happened)
+        if (this.dryRun) {
+            return { decision: SamplingDecision.RECORD_AND_SAMPLED, traceState };
+        }
+
         return { decision, traceState };
     }
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-939

Add support for dry run mode in head sampling. it is set on the HeadSamplingConfig, and when tru, the span evaluates as normal, but never dropped,  and the dry run and if kept or not is reocrded into the trace state which translates to attributes in the processor.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
support dry run in head sampling
```
