### PR TITLE
chore: fix GHSA-xq3m-2v4x-88gg (releases/v0.4.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   "devDependencies": {
     "@types/uuid": "^11.0.0",
     "typescript": "^6.0.2"
+  },
+  "resolutions": {
+    "protobufjs": "^7.5.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-protobufjs@^7.0.0:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+protobufjs@^7.0.0, protobufjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Summary

Backport of the same protobufjs resolution that was applied to `releases/v0.0.x` (commit 579facb) to remediate **GHSA-xq3m-2v4x-88gg** / CVE-2026-41242 (arbitrary code execution in protobufjs `<=7.5.4`).

`@opentelemetry/otlp-transformer` (transitive of `@opentelemetry/exporter-trace-otlp-http`) requests `protobufjs@^7.0.0`, which yarn was resolving to **7.5.4** on this branch. Adding `resolutions: { protobufjs: ^7.5.5 }` forces the patched release.

```release-note
Fix https://github.com/advisories/GHSA-xq3m-2v4x-88gg
```

## Test plan

- [ ] CI green
- [ ] After release as v0.4.1, confirm `node_modules/protobufjs/package.json` reports >= 7.5.5

## Dependents (separate PRs to follow)

- `ebpf-nodejs-instrumentation` `releases/v0.3.x` — bumps `NODEJS_AGENT_BASE_VERSION` to v0.4.1
- `ebpf-nodejs-instrumentation` `releases/v0.4.x` — same
- `odigos-enterprise` `releases/v1.24.0` and `main` — bump nodejs-enterprise pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes RUN-739