### PR TITLE
chore: fix GHSA-xq3m-2v4x-88gg (nodejs-community-14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,8 @@
     "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "typescript": "^5.5.2"
+  },
+  "resolutions": {
+    "protobufjs": "^7.5.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,10 +1002,10 @@ postgres-range@^1.1.1:
   resolved "https://registry.yarnpkg.com/postgres-range/-/postgres-range-1.1.4.tgz#a59c5f9520909bcec5e63e8cf913a92e4c952863"
   integrity sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==
 
-protobufjs@^7.3.0:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
-  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
+protobufjs@^7.3.0, protobufjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
## Summary

Same surgical patch as the `releases/v0.4.x` PR (#86) and the older `releases/v0.0.x` fix (commit 579facb), applied to the `nodejs-community-14` branch.

This branch is consumed by `ebpf-nodejs-instrumentation`'s `nodejs-enterprise-14` image (the Dockerfile in that branch hardcodes `git clone -b nodejs-community-14`), which is in turn bundled into `odigos-enterprise` `main` and `releases/v1.24.0` (`nodejs-enterprise-14:v0.0.18`). Without this patch, the Node 14 path of the upstream agent stays at `protobufjs@7.3.2` even after the v0.4.x stream is patched.

```release-note
Fix https://github.com/advisories/GHSA-xq3m-2v4x-88gg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes RUN-739