### PR TITLE
chore: fix GHSA-xq3m-2v4x-88gg

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   "devDependencies": {
     "@types/uuid": "^11.0.0",
     "typescript": "^6.0.2"
+  },
+  "resolutions": {
+    "protobufjs": "^7.5.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@ postgres-interval@^1.1.0:
   dependencies:
     xtend "^4.0.0"
 
-protobufjs@^7.0.0:
-  version "7.5.4"
-  resolved "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz"
-  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
+protobufjs@^7.0.0, protobufjs@^7.5.5:
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"


### PR DESCRIPTION
fixes RUN-00 
```release-note
Add protobufjs ^7.5.5 to resolutions to remediate GHSA-xq3m-2v4x-88gg
(arbitrary code execution in protobufjs versions <=7.5.4).
```

The transitive dep `@opentelemetry/otlp-transformer` requests
`protobufjs@^7.0.0`, which yarn was resolving to 7.5.4. Forcing it to
^7.5.5 picks up the patched release.

Same surgical patch as v0.0.16 on releases/v0.0.x.

#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->


