### PR TITLE
feat: support disabling and enabling libraries from remote config

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -61,6 +61,26 @@ export interface HeadSamplingConfig {
     noisyOperations: NoisyOperationSamplingConfig[];
 }
 
+export interface InstrumentationLibrary {
+
+    // the programming language of the instrumentation library.
+    // this should already be filtered to include only "javascript"
+    programmingLanguage: string;
+
+    // the name of the instrumentation library.
+    libraryName: string;
+}
+
+// controls which spans should be included or excluded from a trace.
+export interface TraceVerbosityConfig {
+    // list of instrumentation libraries that should be disabled for this trace.
+    disabledLibraries?: InstrumentationLibrary[];
+
+    // list of instrumentation libraries that should be enabled for this trace.
+    // used for opt-in instrumentation libraries that are disabled by default.
+    enabledLibraries?: InstrumentationLibrary[];
+}
+
 export interface TracesConfig {
     // configuration for the traces.
     // it controls the trace and span ids used when starting a new trace or span.
@@ -74,6 +94,8 @@ export interface TracesConfig {
     // configuration for head sampling.
     // if not specified, no head sampling rules will be applied.
     headSampling?: HeadSamplingConfig;
+
+    traceVerbosity?: TraceVerbosityConfig;
 }
 
 export interface ContainerConfig {

--- a/src/instrumentations/config.ts
+++ b/src/instrumentations/config.ts
@@ -1,6 +1,7 @@
 import { RemoteConfig } from "../opamp";
 import { Instrumentation, InstrumentationConfig } from "@opentelemetry/instrumentation";
 import { PubSubInstrumentation } from "./googlepubsub/pubsub-instrumentation";
+import type { ExpressInstrumentationConfig } from "@opentelemetry/instrumentation-express";
 
 import { getAllHeadersInstrumentationConfig, getHttpHeadersFromRemoteConfig, getSpecificHttpHeadersInstrumentationConfig, isCollectingAllHttpHeaders } from "./header-collection";
 
@@ -20,6 +21,10 @@ export interface InstrumentationLibraryManifest {
     // if the instrumentation has a config, it will be passed to the constructor of the instrumentation class
     // and also be used during the remote config update
     config?: InstrumentationConfig | InstrumentationLibraryConfigFunction;
+
+    // if true, the instrumentation library is disabled by default.
+    // can be enabled as opt-in by adding it to the enabledLibraries list in the traceVerbosity instrumentation rule.
+    disabledByDefault?: boolean;
 }
 
 export const instrumentationLibraryManifests: Map<string, InstrumentationLibraryManifest> = new Map([
@@ -47,22 +52,27 @@ export const instrumentationLibraryManifests: Map<string, InstrumentationLibrary
         instrumentationNpmPackage: "@opentelemetry/instrumentation-dataloader",
         import: "DataloaderInstrumentation",
     }],
-    // ["@opentelemetry/instrumentation-dns", {
-    //     instrumentationNpmPackage: "@opentelemetry/instrumentation-dns",
-    //     import: "DnsInstrumentation",
-    // }],
+    ["@opentelemetry/instrumentation-dns", {
+        instrumentationNpmPackage: "@opentelemetry/instrumentation-dns",
+        import: "DnsInstrumentation",
+        disabledByDefault: true,
+    }],
     ["@opentelemetry/instrumentation-express", {
         instrumentationNpmPackage: "@opentelemetry/instrumentation-express",
         import: "ExpressInstrumentation",
+        config: {
+            ignoreLayers: ["middleware - expressInit", "middleware - query"], // added by default in express and give no real visibility value.
+        } as ExpressInstrumentationConfig
     }],
     ["@opentelemetry/instrumentation-fastify", {
         instrumentationNpmPackage: "@opentelemetry/instrumentation-fastify",
         import: "FastifyInstrumentation",
     }],
-    // ["@opentelemetry/instrumentation-fs", {
-    //     instrumentationNpmPackage: "@opentelemetry/instrumentation-fs",
-    //     import: "FsInstrumentation",
-    // }],
+    ["@opentelemetry/instrumentation-fs", {
+        instrumentationNpmPackage: "@opentelemetry/instrumentation-fs",
+        import: "FsInstrumentation",
+        disabledByDefault: true,
+    }],
     ["@opentelemetry/instrumentation-generic-pool", {
         instrumentationNpmPackage: "@opentelemetry/instrumentation-generic-pool",
         import: "GenericPoolInstrumentation",
@@ -143,6 +153,11 @@ export const instrumentationLibraryManifests: Map<string, InstrumentationLibrary
     ["@opentelemetry/instrumentation-nestjs-core", {
         instrumentationNpmPackage: "@opentelemetry/instrumentation-nestjs-core",
         import: "NestInstrumentation",
+    }],
+    ["@opentelemetry/instrumentation-net", {
+        instrumentationNpmPackage: "@opentelemetry/instrumentation-net",
+        import: "NetInstrumentation",
+        disabledByDefault: true,
     }],
     ["@opentelemetry/instrumentation-pg", {
         instrumentationNpmPackage: "@opentelemetry/instrumentation-pg",

--- a/src/instrumentations/index.ts
+++ b/src/instrumentations/index.ts
@@ -1,6 +1,6 @@
 import { Instrumentation } from "@opentelemetry/instrumentation";
 import { InstrumentationLibraryConfigFunction, InstrumentationLibraryManifest, instrumentationLibraryManifests } from "./config";
-import { createInstrumentationLibraryInstance, isCollectingTraces, parseDisabledInstrumentations, resolveBaseConfig } from "./utils";
+import { calculateLibraryTracesEnabled, createInstrumentationLibraryInstance, isCollectingTraces, parseDisabledInstrumentations, resolveBaseConfig } from "./utils";
 import { diag, ProxyTracerProvider, trace, TracerProvider } from "@opentelemetry/api";
 import { RemoteConfig } from "../opamp";
 
@@ -36,16 +36,29 @@ export class InstrumentationLibraries {
     public updateConfig(remoteConfig: RemoteConfig | undefined, tracerProvider: TracerProvider | undefined): void {
 
         const collectingTraces = isCollectingTraces(remoteConfig);
-        const tracerProviderInUse = collectingTraces && tracerProvider ? tracerProvider : this.noopTracerProvider;
 
-        // set global tracer provider to record traces from 3rd party instrumented libraries
+        const disabledLibraryNames = remoteConfig?.containerConfig.traces?.traceVerbosity?.disabledLibraries
+            ?.map(lib => lib.libraryName);
+        const disabledLibraryNamesSet = new Set(disabledLibraryNames ?? []);
+
+        const enabledLibraryNames = remoteConfig?.containerConfig.traces?.traceVerbosity?.enabledLibraries
+            ?.map(lib => lib.libraryName);
+        const enabledLibraryNamesSet = new Set(enabledLibraryNames ?? []);
+
         for (const [_, instrumentationLibrary] of this.instrumentationLibraries.entries()) {
             const resolvedConfig = resolveBaseConfig(instrumentationLibrary.manifest, remoteConfig);
             const additionalConfig = instrumentationLibrary.additionalConfig?.(instrumentationLibrary.manifest.instrumentationNpmPackage, remoteConfig, resolvedConfig);
             const effectiveConfig = { ...resolvedConfig, ...additionalConfig };
 
             instrumentationLibrary.instrumentationInstance.setConfig(effectiveConfig ?? {});
-            instrumentationLibrary.instrumentationInstance.setTracerProvider(tracerProviderInUse);
+
+            const isDisabledByConfig = disabledLibraryNamesSet.has(instrumentationLibrary.manifest.instrumentationNpmPackage);
+            const isEnabledByConfig = enabledLibraryNamesSet.has(instrumentationLibrary.manifest.instrumentationNpmPackage);
+            const isDisabledByDefault = !!instrumentationLibrary.manifest.disabledByDefault;
+            const tracesEnabled = calculateLibraryTracesEnabled(collectingTraces, isDisabledByConfig, isEnabledByConfig, isDisabledByDefault);
+
+            const libraryProvider = (tracesEnabled && tracerProvider) ? tracerProvider : this.noopTracerProvider;
+            instrumentationLibrary.instrumentationInstance.setTracerProvider(libraryProvider);
         }
     }
 

--- a/src/instrumentations/utils.ts
+++ b/src/instrumentations/utils.ts
@@ -88,3 +88,28 @@ const safeCreateInstrumentationLibrary = (
 export const isCollectingTraces = (remoteConfig: RemoteConfig | undefined): boolean => {
     return remoteConfig?.containerConfig.traces !== undefined;
 }
+
+// givin the relevant configurations for a specific instrumentation library, returns true if the library should be traced.
+export const calculateLibraryTracesEnabled = (collectingTraces: boolean, isDisabledByConfig: boolean, isEnabledByConfig: boolean, isDisabledByDefault: boolean): boolean => {
+
+    // when there is no traces destination or span-metrics, we don't need to collect traces from any instrumentation libraries.
+    if (!collectingTraces) {
+        return false;
+    }
+
+    if (isDisabledByConfig) {
+        return false;
+    }
+
+    // noisy instrumentation libraries are disabled by default.
+    // we check if they are opt-in  (if they are enabled by config)
+    if (isDisabledByDefault) {
+        if (isEnabledByConfig) {
+            return true;
+        }
+        return false;
+    }
+
+    // instrumentation libraries are enabled by default if no other configuration is provided.
+    return true;
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-954

Add support for disabling and enabling libraries based on the remote config.

3 libraries are disabled by default and can be enabled:

- dns
- fs
- net

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
Add support for disabling and enabling libraries based on the remote config
```
