### PR TITLE
chore: remove unused old opeamp config sections

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
 node_modules # don't include node_modules in the context, as it is being installed fresh in the Dockerfile
+build
+examples
+varodigos
+development

--- a/src/opamp/client-http.ts
+++ b/src/opamp/client-http.ts
@@ -71,7 +71,6 @@ export class OpAMPClientHttp {
 
     // on any issue connection to opamp server, this will be the default remote config which will be applied
     this.defaultRemoteConfig = {
-      instrumentationLibraries: [],
       containerConfig: {
         traces: {}, // default (if remote config is not set) is to collect traces
       },

--- a/src/opamp/remote-config.ts
+++ b/src/opamp/remote-config.ts
@@ -1,31 +1,10 @@
 import { AgentRemoteConfig } from "./generated/opamp_pb";
-import { InstrumentationLibraryConfiguration, RemoteConfig } from "./types";
-import { OpAMPSdkConfiguration } from "./opamp-types";
+import { RemoteConfig } from "./types";
 import { ContainerConfig } from "../config";
 
 export const extractRemoteConfigFromResponse = (
   agentRemoteConfig: AgentRemoteConfig,
 ): RemoteConfig => {
-
-  const instrumentationLibrariesConfigSection =
-    agentRemoteConfig.config?.configMap["InstrumentationLibraries"];
-  if (
-    !instrumentationLibrariesConfigSection ||
-    !instrumentationLibrariesConfigSection.body
-  ) {
-    throw new Error("missing instrumentation libraries remote config");
-  }
-  const instrumentationLibrariesConfigBody =
-    instrumentationLibrariesConfigSection.body.toString();
-
-  let instrumentationLibrariesConfig: InstrumentationLibraryConfiguration[];
-  try {
-    instrumentationLibrariesConfig = JSON.parse(
-      instrumentationLibrariesConfigBody
-    ) as InstrumentationLibraryConfiguration[];
-  } catch (error) {
-    throw new Error("error parsing instrumentation libraries remote config");
-  }
 
   const containerConfigSection = agentRemoteConfig.config?.configMap["container_config"];
   if (!containerConfigSection || !containerConfigSection.body) {
@@ -40,7 +19,6 @@ export const extractRemoteConfigFromResponse = (
   }
 
   return {
-    instrumentationLibraries: instrumentationLibrariesConfig,
     containerConfig,
   };
 };

--- a/src/opamp/types.ts
+++ b/src/opamp/types.ts
@@ -24,20 +24,9 @@ export interface TraceSignalGeneralConfig {
   defaultEnabledValue: boolean;
 }
 
-// InstrumentationLibrary Remote Configuration
-export interface InstrumentationLibraryTracesConfiguration {
-  // if the value is set, use it, otherwise use the default value from the trace signal in the sdk level
-  enabled?: boolean;
-}
-export interface InstrumentationLibraryConfiguration {
-  name: string;
-  traces: InstrumentationLibraryTracesConfiguration;
-}
-
 // All remote config fields
 
 export type RemoteConfig = {
-  instrumentationLibraries: InstrumentationLibraryConfiguration[];
   containerConfig: ContainerConfig;
 };
 


### PR DESCRIPTION
#### What this PR does / why we need it:

fixes: CORE-000

remove the "InstrumentationLibraries" opamp config section entry which is not used anymore

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
