### PR TITLE
ci: login to depot with token from secret

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -31,8 +31,9 @@ on:
         type: string
 
 env:
-  ECR_REPO_NODEJS_COMMUNITY: public.ecr.aws/odigos/agents/nodejs-community
-  DEPOT_REPO_NODEJS_COMMUNITY: p0xd21zf5r.registry.depot.dev/nodejs-community
+  DOCKER_REPOSITORY_NAME: nodejs-community
+  ECR_REGISTRY: public.ecr.aws/odigos/agents
+  DEPOT_REGISTRY: p0xd21zf5r.registry.depot.dev
 
 jobs:
   # ── 1. Calculate the next version ─────────────────────────────────────────
@@ -205,15 +206,18 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 \
           | docker login --username AWS --password-stdin public.ecr.aws
 
+      - name: Login to Depot Registry
+        run: docker login --username x-token --password ${{ secrets.DEPOT_PUSH_TOKEN }} ${DEPOT_REGISTRY}
+
       - name: Compute Docker tags
         id: docker-tags
         env:
           NEW_VERSION: ${{ needs.calculate.outputs.new_version }}
           IS_PRERELEASE: ${{ needs.calculate.outputs.is_prerelease }}
         run: |
-          COMMUNITY="${ECR_REPO_NODEJS_COMMUNITY}:${NEW_VERSION},${DEPOT_REPO_NODEJS_COMMUNITY}:${NEW_VERSION}"
+          COMMUNITY="${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION},${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION}"
           if [[ "${IS_PRERELEASE}" == "false" ]]; then
-            COMMUNITY="${COMMUNITY},${ECR_REPO_NODEJS_COMMUNITY}:latest,${DEPOT_REPO_NODEJS_COMMUNITY}:latest"
+            COMMUNITY="${COMMUNITY},${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest,${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest"
           fi
           echo "community=${COMMUNITY}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-947

Since it's a named repository in depot, the OIDC token which is tied to a project is not relevant. the only supported way to do it now is via an authentication token in secrets

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```
