### PR TITLE
fix: handle head sampling without noisy operations

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -58,7 +58,7 @@ export interface HeadSamplingConfig {
 
     // configuration for the noisy operations.
     // if not specified, no noisy operations will be applied.
-    noisyOperations: NoisyOperationSamplingConfig[];
+    noisyOperations?: NoisyOperationSamplingConfig[];
 }
 
 export interface InstrumentationLibrary {

--- a/src/sampler/index.ts
+++ b/src/sampler/index.ts
@@ -1,4 +1,4 @@
-import { Attributes, Context, createTraceState, Link, SpanKind } from "@opentelemetry/api";
+import { Attributes, Context, createTraceState, diag, Link, SpanKind } from "@opentelemetry/api";
 import { Sampler, SamplingDecision, SamplingResult } from "@opentelemetry/sdk-trace-base";
 import { HeadSamplingConfig, NoisyOperationSamplingConfig } from "../config";
 import { parseHttpServerAttributes, parseHttpClientAttributes } from "./utils";
@@ -9,36 +9,43 @@ import { createHttpMethodMatcher, createHttpPathMatcher, createHttpServerAddress
 export class OdigosHeadSampler implements Sampler {
 
     private serviceRules: NoisyOperationSamplingConfig[];
-    private httpServerRules: ParsedHttpRule[];
-    private httpClientRules: ParsedHttpRule[];
-    private dryRun: boolean;
+    private httpServerRules: ParsedHttpRule[] = [];
+    private httpClientRules: ParsedHttpRule[] = [];
+    private dryRun: boolean = false;
 
     constructor(config: HeadSamplingConfig) {
         this.serviceRules = [];
         const httpServerRules: ParsedHttpRule[] = [];
         const httpClientRules: ParsedHttpRule[] = [];
 
-        for (const rule of config.noisyOperations) {
-            if (rule.disabled) {
-                continue;
+        try {
+
+            const noisyOperations = config.noisyOperations ?? [];
+            for (const rule of noisyOperations) {
+                if (rule.disabled) {
+                    continue;
+                }
+                
+                if (!rule.operation) {
+                    this.serviceRules.push(rule);
+                } else if (rule.operation.httpServer) {
+                    const pathMatcher = createHttpPathMatcher(rule.operation.httpServer.route, rule.operation.httpServer.routePrefix);
+                    const methodMatcher = createHttpMethodMatcher(rule.operation.httpServer.method);
+                    httpServerRules.push({ pathMatcher, methodMatcher, rule });
+                } else if (rule.operation.httpClient) {
+                    const pathMatcher = createHttpPathMatcher(rule.operation.httpClient.templatedPath, rule.operation.httpClient.templatedPathPrefix);
+                    const methodMatcher = createHttpMethodMatcher(rule.operation.httpClient.method);
+                    const serverAddressMatcher = createHttpServerAddressMatcher(rule.operation.httpClient.serverAddress);
+                    httpClientRules.push({ pathMatcher, methodMatcher, serverAddressMatcher, rule });
+                }
             }
 
-            if (!rule.operation) {
-                this.serviceRules.push(rule);
-            } else if (rule.operation.httpServer) {
-                const pathMatcher = createHttpPathMatcher(rule.operation.httpServer.route, rule.operation.httpServer.routePrefix);
-                const methodMatcher = createHttpMethodMatcher(rule.operation.httpServer.method);
-                httpServerRules.push({ pathMatcher, methodMatcher, rule });
-            } else if (rule.operation.httpClient) {
-                const pathMatcher = createHttpPathMatcher(rule.operation.httpClient.templatedPath, rule.operation.httpClient.templatedPathPrefix);
-                const methodMatcher = createHttpMethodMatcher(rule.operation.httpClient.method);
-                const serverAddressMatcher = createHttpServerAddressMatcher(rule.operation.httpClient.serverAddress);
-                httpClientRules.push({ pathMatcher, methodMatcher, serverAddressMatcher, rule });
-            }
+            this.httpServerRules = httpServerRules;
+            this.httpClientRules = httpClientRules;
+            this.dryRun = config.dryRun ?? false;
+        } catch (error) {
+            diag.error('Error initializing OdigosHeadSampler:', error);
         }
-        this.httpServerRules = httpServerRules;
-        this.httpClientRules = httpClientRules;
-        this.dryRun = config.dryRun ?? false;
     }
 
     shouldSample(context: Context, traceId: string, spanName: string, spanKind: SpanKind, attributes: Attributes, links: Link[]): SamplingResult {
@@ -90,7 +97,7 @@ export class OdigosHeadSampler implements Sampler {
         const routeOrPath = parsed.route || parsed.path;
         if (!routeOrPath) return []; // http span mush have a route or a path.
         const segments = routeOrPath.split('/');
-        
+
         const upperCaseMethod = parsed.method.toUpperCase();
 
         return this.httpServerRules
@@ -106,7 +113,7 @@ export class OdigosHeadSampler implements Sampler {
         const httpPath = parsed.templatedPath || parsed.path;
         if (!httpPath) return []; // http span mush have a path.
         const segments = httpPath.split('/');
-        
+
         const upperCaseMethod = parsed.method.toUpperCase();
         const lowerCaseServerAddress = parsed.serverAddress?.toLowerCase();
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-947

With span metrics mode "all-spans", we can get head-sampling config with no noisy-operations configs. This PR handles this case which is now throwing an exception

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix head sampling error when there are no noisy operations
```
