### PR TITLE
ci: use the correct major version for cherry-pick

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -20,6 +20,7 @@ jobs:
       pr_title: ${{ steps.extract.outputs.pr_title }}
       pr_user_login: ${{ steps.extract.outputs.pr_user_login }}
       original_pr_body: ${{ steps.extract.outputs.original_pr_body }}
+      major_version: "0"
     steps:
       - name: Extract cherry-pick targets
         id: extract


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1122

fix issue with cherry-pick action - set major version to '0' for cherry-pick check

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

<!--
Cherry-pick (optional): to backport to release branches after merge, add a line like:
cherry-pick: v0.6
Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
-->
