### PR TITLE
fix(google-pub-sub): remove double patching of publish on legacy api

### DIFF
--- a/src/instrumentations/googlepubsub/pubsub-instrumentation.ts
+++ b/src/instrumentations/googlepubsub/pubsub-instrumentation.ts
@@ -54,7 +54,6 @@ export class PubSubInstrumentation extends InstrumentationBase<PubSubInstrumenta
             const TopicProto = (moduleExports as any).Topic?.prototype;
             if (TopicProto) {
               (self as any)._wrap(TopicProto, "publishMessage", self._createPublishMessageWrap());
-              (self as any)._wrap(TopicProto, "publish", self._createPublishLegacyWrap());
             }
             const PublisherProto = (moduleExports as any).Publisher?.prototype;
             if (PublisherProto) {
@@ -166,76 +165,19 @@ export class PubSubInstrumentation extends InstrumentationBase<PubSubInstrumenta
           // fail-open
         }
 
-        const exec = () => original.apply(this, [msgObj, ...rest]);
-        return safeExecuteInTheMiddle(
-          exec,
-          (err, result) => {
-            if (span) {
-              try {
-                if (err) span.recordException(err as any);
-                span.end();
-              } catch { }
-            }
-          },
-          true
-        );
-      } as any;
-    };
-  }
-
-  private _createPublishLegacyWrap() {
-    const self = this;
-    return function (original: (...args: any[]) => any): any {
-      return function wrapped(this: any, data: any, attributes?: Record<string, string>, ...rest: any[]) {
-        const tracer = (self as any).tracer;
-        const topicFullName: string | undefined = safeGetTopicName(this);
-        const topicDisplay = normalizeDisplayName(topicFullName);
-
-        const env = (globalThis as any).process?.env || {};
-        const enableSpans = env.OTEL_PUBSUB_SPANS !== "0";
-        const enableProp = env.OTEL_PUBSUB_PROPAGATION !== "0";
-
-        let span: Span | undefined;
-        const activeCtx = context.active();
-        const spanName = topicDisplay ? `PubSub publish ${topicDisplay}` : "PubSub publish";
-        if (enableSpans) {
-          span = tracer.startSpan(
-            spanName,
-            {
-              kind: SpanKind.PRODUCER,
-              attributes: buildCommonMessagingAttrs(topicFullName, "publish", data),
+        return context.with(ctxForInject, () =>
+          safeExecuteInTheMiddle(
+            () => original.apply(this, [msgObj, ...rest]),
+            (err, result) => {
+              if (span) {
+                try {
+                  if (err) span.recordException(err as any);
+                  span.end();
+                } catch { }
+              }
             },
-            activeCtx
-          );
-
-          const config = self.getConfig();
-          try {
-            config?.onPublishMessageHook?.(span, { data });
-          } catch (e) {
-            this.diag.error('Error calling onProcessMessageHook', e);
-          }
-        }
-
-        const ctxForInject = span ? trace.setSpan(activeCtx, span) : activeCtx;
-        let attrs = attributes;
-        try {
-          if (enableProp) {
-            attrs = injectIfMissing(ensureAttributes(attributes), ctxForInject);
-          }
-        } catch { }
-
-        const exec = () => original.apply(this, [data, attrs, ...rest]);
-        return safeExecuteInTheMiddle(
-          exec,
-          (err: unknown) => {
-            if (span) {
-              try {
-                if (err) span.recordException(err as any);
-                span.end();
-              } catch { }
-            }
-          },
-          true
+            true
+          )
         );
       } as any;
     };


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes: CORE-1159

We were patching both new and legacy publish api, but the legacy was calling the new one, which caused 2 spans to be emitted per publish operation.

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
fix(google-pub-sub): when publishing with legacy api, 2 spans are created per publish
```

<!--
Cherry-pick (optional): to backport to release branches after merge, add a line like:
cherry-pick: v0.6
Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
-->
