### PR TITLE
ci: try publishing agent images to gcp

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -34,6 +34,8 @@ env:
   DOCKER_REPOSITORY_NAME: nodejs-community
   ECR_REGISTRY: public.ecr.aws/odigos/agents
   DEPOT_REGISTRY: p0xd21zf5r.registry.depot.dev
+  GCP_REGISTRY: northamerica-northeast1-docker.pkg.dev/odigos-cloud/agents
+  GCP_DOCKER_HOST: northamerica-northeast1-docker.pkg.dev
 
 jobs:
   # ── 1. Calculate the next version ─────────────────────────────────────────
@@ -195,6 +197,20 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: projects/${{ env.GCP_PROJECT_NUMBER }}/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: agent-images-publisher@odigos-cloud.iam.gserviceaccount.com
+
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v4
+        with:
+          registry: northamerica-northeast1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:
@@ -215,9 +231,9 @@ jobs:
           NEW_VERSION: ${{ needs.calculate.outputs.new_version }}
           IS_PRERELEASE: ${{ needs.calculate.outputs.is_prerelease }}
         run: |
-          COMMUNITY="${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION},${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION}"
+          COMMUNITY="${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION},${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION},${GCP_REGISTRY}/${DOCKER_REPOSITORY_NAME}:${NEW_VERSION}"
           if [[ "${IS_PRERELEASE}" == "false" ]]; then
-            COMMUNITY="${COMMUNITY},${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest,${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest"
+            COMMUNITY="${COMMUNITY},${ECR_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest,${DEPOT_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest,${GCP_REGISTRY}/${DOCKER_REPOSITORY_NAME}:latest"
           fi
           echo "community=${COMMUNITY}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
#### What this PR does / why we need it:

experiment to replace ecr for gcp. currently publishing to both

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

<!--
Cherry-pick (optional): to backport to release branches after merge, add a line like:
cherry-pick: v0.6
Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
-->
