### PR TITLE
CORE-1191: use new ci-core version update dispatch to update odigos oss

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -248,27 +248,9 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Get sts token for Odigos OSS repo
-        id: sts-oss
-        uses: odigos-io/ci-core/sts@main
+      - name: Trigger agents version update in consumer repos
+        uses: odigos-io/ci-core/dispatch-agent-version-update@main
         with:
-          scope: odigos-io/odigos
-          identity: trigger-agent-version-updater
-          output-git-config: "false"
-
-      - name: Trigger update instrumentation agents version workflow
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ steps.sts-oss.outputs.GH_TOKEN }}
-          repository: odigos-io/odigos
-          event-type: update-instrumentation-agents-version
-          client-payload: '{"agents_category": "nodejs", "new_agent_version": "${{ needs.calculate.outputs.new_version }}"}'
-
-      - name: Notify Slack
-        if: always()
-        uses: odigos-io/ci-core/.github/actions/slack-release-notification@main
-        with:
-          webhook-url: ${{ secrets.ODIGOS_RELEASE_STATUS_WEBHOOK_URL }}
-          success-description: "Triggered the Odigos instrumentation agents version update"
-          failure-description: "ERROR: Failed to trigger the Odigos instrumentation agents version update"
-          tag: ${{ needs.calculate.outputs.new_version }}
+          instrumentation_agent: nodejs-community
+          version: ${{ needs.calculate.outputs.new_version }}
+          consumers: odigos


### PR DESCRIPTION
#### What this PR does / why we need it:
<!--
Please add a meaningful description for future maintainers on what this change does and why we need it.
-->

#### Changelog entry: Does this PR introduce a user-facing bug fix, feature, dependency update, or breaking change??
<!--
This section will go in the release notes for this version. Is this something users should be able to find easily?
If no, just write "NONE" in the release-note block below.
If yes, please add a release note in the block below describing this in 1-2 sentences for our changelog.
-->

```release-note
NONE
```

<!--
Cherry-pick (optional): to backport to release branches after merge, add a line like:
cherry-pick: v0.6
Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
-->
