### PR TITLE
ci: add PR policy and release note template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,9 @@ If yes, please add a release note in the block below describing this in 1-2 sent
 ```release-note
 
 ```
+
+<!--
+Cherry-pick (optional): to backport to release branches after merge, add a line like:
+cherry-pick: v0.6
+Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,9 +13,3 @@ If yes, please add a release note in the block below describing this in 1-2 sent
 ```release-note
 
 ```
-
-<!--
-Cherry-pick (optional): to backport to release branches after merge, add a line like:
-cherry-pick: v0.6
-Comma-separated versions are supported, e.g. cherry-pick: v0.6, v0.7
--->

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -14,3 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: odigos-io/ci-core/require-linear@main
+
+  release-note:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: odigos-io/ci-core/require-release-note@main


### PR DESCRIPTION
## Summary
- Add PR policy checks for linked Linear issues and release-note blocks where needed.
- Add the standard Odigos PR template so release-note guidance is present when opening PRs.

## Notes
- Branch protection changes are handled separately after these PRs are reviewed and merged.

```release-note
NONE
```
